### PR TITLE
Fix separate audio compile error

### DIFF
--- a/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
@@ -10,6 +10,7 @@
 #include "Common/CommonTypes.h"
 #include "Common/Logging/Log.h"
 
+#include "Core/Config/MainSettings.h"
 #include "Core/ConfigManager.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/System.h"
@@ -128,6 +129,11 @@ void SpeakerLogic::SpeakerData(const u8* data, int length, float speaker_pan)
 
   auto& system = Core::System::GetInstance();
   SoundStream* sound_stream = system.GetSoundStream();
+  if (Config::Get(Config::MAIN_WIIMOTE_SEPARATE_AUDIO) && m_parent)
+  {
+    if (SoundStream* wm_stream = system.GetWiimoteSoundStream(m_parent->GetWiimoteDeviceIndex()))
+      sound_stream = wm_stream;
+  }
 
   sound_stream->GetMixer()->SetWiimoteSpeakerVolume(l_volume, r_volume);
 

--- a/Source/Core/Core/HW/WiimoteEmu/Speaker.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Speaker.h
@@ -30,6 +30,7 @@ public:
   void DoState(PointerWrap& p);
 
   void SetSpeakerEnabled(bool enabled);
+  void SetParent(Wiimote* parent) { m_parent = parent; }
 
 private:
   // Pan is -1.0 to +1.0
@@ -75,6 +76,8 @@ private:
   ControllerEmu::SettingValue<double> m_speaker_pan_setting;
 
   bool m_speaker_enabled = false;
+
+  Wiimote* m_parent = nullptr;
 };
 
 }  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -203,6 +203,7 @@ void Wiimote::Reset()
 
 Wiimote::Wiimote(const unsigned int index) : m_index(index), m_bt_device_index(index)
 {
+  m_speaker_logic.SetParent(this);
   using Translatability = ControllerEmu::Translatability;
 
   // Buttons


### PR DESCRIPTION
## Summary
- include `MainSettings` in `Speaker.cpp`
- keep config constant accessible for per-Wiimote audio routing

## Testing
- `./Tools/lint.sh --force`
