### PR TITLE
Add per-Wiimote audio device support

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.h
+++ b/Source/Core/AudioCommon/AudioCommon.h
@@ -31,6 +31,8 @@ bool SupportsLatencyControl(std::string_view backend);
 bool SupportsVolumeChanges(std::string_view backend);
 void UpdateSoundStream(Core::System& system);
 void SetSoundStreamRunning(Core::System& system, bool running);
+void InitWiimoteSoundStreams(Core::System& system);
+void ShutdownWiimoteSoundStreams(Core::System& system);
 void SendAIBuffer(Core::System& system, const short* samples, unsigned int num_samples);
 void StartAudioDump(Core::System& system);
 void StopAudioDump(Core::System& system);

--- a/Source/Core/AudioCommon/WASAPIStream.cpp
+++ b/Source/Core/AudioCommon/WASAPIStream.cpp
@@ -176,19 +176,19 @@ bool WASAPIStream::SetRunning(bool running)
 
     HRESULT result;
 
-    if (Config::Get(Config::MAIN_WASAPI_DEVICE) == "default")
+    if (m_device == "default")
     {
       result = m_enumerator->GetDefaultAudioEndpoint(eRender, eConsole, device.GetAddressOf());
     }
     else
     {
       result = S_OK;
-      device = GetDeviceByName(Config::Get(Config::MAIN_WASAPI_DEVICE));
+      device = GetDeviceByName(m_device);
 
       if (!device)
       {
         ERROR_LOG_FMT(AUDIO, "Can't find device '{}', falling back to default",
-                      Config::Get(Config::MAIN_WASAPI_DEVICE));
+                      m_device);
         result = m_enumerator->GetDefaultAudioEndpoint(eRender, eConsole, device.GetAddressOf());
       }
     }

--- a/Source/Core/AudioCommon/WASAPIStream.h
+++ b/Source/Core/AudioCommon/WASAPIStream.h
@@ -35,6 +35,7 @@ public:
   ~WASAPIStream();
   bool Init() override;
   bool SetRunning(bool running) override;
+  void SetDevice(const std::string& device) { m_device = device; }
 
   static bool IsValid();
   static std::vector<std::string> GetAvailableDevices();
@@ -56,5 +57,6 @@ private:
   Microsoft::WRL::ComPtr<IAudioRenderClient> m_audio_renderer;
   wil::unique_event_nothrow m_need_data_event;
   WAVEFORMATEXTENSIBLE m_format;
+  std::string m_device = "default";
 #endif  // _WIN32
 };

--- a/Source/Core/Core/Config/MainSettings.cpp
+++ b/Source/Core/Core/Config/MainSettings.cpp
@@ -4,6 +4,7 @@
 #include "Core/Config/MainSettings.h"
 
 #include <sstream>
+#include <array>
 
 #include <fmt/format.h>
 
@@ -193,6 +194,14 @@ const Info<bool> MAIN_WIIMOTE_CONTINUOUS_SCANNING{
 const Info<std::string> MAIN_WIIMOTE_AUTO_CONNECT_ADDRESSES{
     {System::Main, "Core", "WiimoteAutoConnectAddresses"}, ""};
 const Info<bool> MAIN_WIIMOTE_ENABLE_SPEAKER{{System::Main, "Core", "WiimoteEnableSpeaker"}, false};
+const Info<bool> MAIN_WIIMOTE_SEPARATE_AUDIO{{System::Main, "Core", "WiimoteSeparateAudio"}, false};
+#ifdef _WIN32
+const std::array<Info<std::string>, 4> MAIN_WIIMOTE_WASAPI_DEVICES{
+    Info<std::string>{{System::Main, "Core", "Wiimote1WASAPIDevice"}, "default"},
+    Info<std::string>{{System::Main, "Core", "Wiimote2WASAPIDevice"}, "default"},
+    Info<std::string>{{System::Main, "Core", "Wiimote3WASAPIDevice"}, "default"},
+    Info<std::string>{{System::Main, "Core", "Wiimote4WASAPIDevice"}, "default"}};
+#endif
 const Info<bool> MAIN_CONNECT_WIIMOTES_FOR_CONTROLLER_INTERFACE{
     {System::Main, "Core", "WiimoteControllerInterface"}, false};
 const Info<bool> MAIN_MMU{{System::Main, "Core", "MMU"}, false};

--- a/Source/Core/Core/Config/MainSettings.h
+++ b/Source/Core/Core/Config/MainSettings.h
@@ -109,6 +109,10 @@ extern const Info<bool> MAIN_WII_KEYBOARD;
 extern const Info<bool> MAIN_WIIMOTE_CONTINUOUS_SCANNING;
 extern const Info<std::string> MAIN_WIIMOTE_AUTO_CONNECT_ADDRESSES;
 extern const Info<bool> MAIN_WIIMOTE_ENABLE_SPEAKER;
+extern const Info<bool> MAIN_WIIMOTE_SEPARATE_AUDIO;
+#ifdef _WIN32
+extern const std::array<Info<std::string>, 4> MAIN_WIIMOTE_WASAPI_DEVICES;
+#endif
 extern const Info<bool> MAIN_CONNECT_WIIMOTES_FOR_CONTROLLER_INTERFACE;
 extern const Info<bool> MAIN_MMU;
 extern const Info<bool> MAIN_PAUSE_ON_PANIC;

--- a/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/Speaker.cpp
@@ -4,6 +4,7 @@
 #include "Core/HW/WiimoteEmu/Speaker.h"
 
 #include <cassert>
+#include <algorithm>
 
 #include "AudioCommon/AudioCommon.h"
 
@@ -13,6 +14,7 @@
 #include "Core/ConfigManager.h"
 #include "Core/HW/WiimoteEmu/WiimoteEmu.h"
 #include "Core/System.h"
+#include "Core/Config/MainSettings.h"
 
 #include "InputCommon/ControllerEmu/ControlGroup/ControlGroup.h"
 #include "InputCommon/ControllerEmu/Setting/NumericSetting.h"
@@ -127,7 +129,11 @@ void SpeakerLogic::SpeakerData(const u8* data, int length, float speaker_pan)
   const u32 r_volume = std::min(u32(std::min(1.f + speaker_pan, 1.f) * volume), 255u);
 
   auto& system = Core::System::GetInstance();
-  SoundStream* sound_stream = system.GetSoundStream();
+  SoundStream* sound_stream = nullptr;
+  if (Config::Get(Config::MAIN_WIIMOTE_SEPARATE_AUDIO))
+    sound_stream = system.GetWiimoteSoundStream(m_index);
+  if (!sound_stream)
+    sound_stream = system.GetSoundStream();
 
   sound_stream->GetMixer()->SetWiimoteSpeakerVolume(l_volume, r_volume);
 

--- a/Source/Core/Core/HW/WiimoteEmu/Speaker.h
+++ b/Source/Core/Core/HW/WiimoteEmu/Speaker.h
@@ -31,6 +31,9 @@ public:
 
   void SetSpeakerEnabled(bool enabled);
 
+  void SetIndex(u8 index) { m_index = index; }
+  u8 GetIndex() const { return m_index; }
+
 private:
   // Pan is -1.0 to +1.0
   void SpeakerData(const u8* data, int length, float speaker_pan);
@@ -75,6 +78,7 @@ private:
   ControllerEmu::SettingValue<double> m_speaker_pan_setting;
 
   bool m_speaker_enabled = false;
+  u8 m_index = 0;
 };
 
 }  // namespace WiimoteEmu

--- a/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
+++ b/Source/Core/Core/HW/WiimoteEmu/WiimoteEmu.cpp
@@ -203,6 +203,7 @@ void Wiimote::Reset()
 
 Wiimote::Wiimote(const unsigned int index) : m_index(index), m_bt_device_index(index)
 {
+  m_speaker_logic.SetIndex(index);
   using Translatability = ControllerEmu::Translatability;
 
   // Buttons

--- a/Source/Core/Core/System.cpp
+++ b/Source/Core/Core/System.cpp
@@ -4,6 +4,7 @@
 #include "Core/System.h"
 
 #include <memory>
+#include <array>
 
 #include "AudioCommon/SoundStream.h"
 #include "Core/Config/MainSettings.h"
@@ -60,6 +61,7 @@ struct System::Impl
   }
 
   std::unique_ptr<SoundStream> m_sound_stream;
+  std::array<std::unique_ptr<SoundStream>, 4> m_wiimote_sound_streams;
   bool m_sound_stream_running = false;
   bool m_audio_dump_started = false;
 
@@ -123,6 +125,19 @@ SoundStream* System::GetSoundStream() const
 void System::SetSoundStream(std::unique_ptr<SoundStream> sound_stream)
 {
   m_impl->m_sound_stream = std::move(sound_stream);
+}
+
+SoundStream* System::GetWiimoteSoundStream(size_t index) const
+{
+  if (index >= m_impl->m_wiimote_sound_streams.size())
+    return nullptr;
+  return m_impl->m_wiimote_sound_streams[index].get();
+}
+
+void System::SetWiimoteSoundStream(size_t index, std::unique_ptr<SoundStream> stream)
+{
+  if (index < m_impl->m_wiimote_sound_streams.size())
+    m_impl->m_wiimote_sound_streams[index] = std::move(stream);
 }
 
 bool System::IsSoundStreamRunning() const

--- a/Source/Core/Core/System.h
+++ b/Source/Core/Core/System.h
@@ -153,6 +153,8 @@ public:
 
   SoundStream* GetSoundStream() const;
   void SetSoundStream(std::unique_ptr<SoundStream> sound_stream);
+  SoundStream* GetWiimoteSoundStream(size_t index) const;
+  void SetWiimoteSoundStream(size_t index, std::unique_ptr<SoundStream> stream);
   bool IsSoundStreamRunning() const;
   void SetSoundStreamRunning(bool running);
   bool IsAudioDumpStarted() const;

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.h
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.h
@@ -70,6 +70,8 @@ private:
   QCheckBox* m_wiimote_continuous_scanning;
   QCheckBox* m_wiimote_real_balance_board;
   QCheckBox* m_wiimote_speaker_data;
+  QCheckBox* m_wiimote_separate_audio;
+  std::array<QComboBox*, 4> m_wiimote_device_boxes;
   QCheckBox* m_wiimote_ciface;
   QPushButton* m_wiimote_refresh;
   QLabel* m_bluetooth_unavailable;


### PR DESCRIPTION
## Summary
- add per-Wiimote audio configs and device strings
- create getter/setter for Wiimote sound streams in `System`
- implement initialization of separate Wiimote sound streams
- expose device selection in the controller UI
- route speaker output to per-Wiimote sound streams when enabled

## Testing
- `Tools/lint.sh --force` *(no output)*
