### PR TITLE
Implement Wiimote speaker audio stream

### DIFF
--- a/Source/Core/AudioCommon/AudioCommon.h
+++ b/Source/Core/AudioCommon/AudioCommon.h
@@ -39,4 +39,5 @@ void StopAudioDump(Core::System& system);
 void IncreaseVolume(Core::System& system, unsigned short offset);
 void DecreaseVolume(Core::System& system, unsigned short offset);
 void ToggleMuteVolume(Core::System& system);
+void PlayWiimoteSpeakerTestTone(Core::System& system, size_t index);
 }  // namespace AudioCommon

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.cpp
@@ -20,6 +20,7 @@
 #ifdef _WIN32
 #include "AudioCommon/WASAPIStream.h"
 #endif
+#include "AudioCommon/AudioCommon.h"
 
 #include "Common/Config/Config.h"
 #include "Common/WorkQueueThread.h"
@@ -211,6 +212,7 @@ void WiimoteControllersWidget::CreateLayout()
                                                  GetLayoutHorizontalSpacing(m_wiimote_layout));
   m_wiimote_layout->setColumnStretch(2, 1);
   m_wiimote_layout->setColumnStretch(4, 1);
+  m_wiimote_layout->setColumnStretch(5, 1);
 
   // Passthrough BT
   m_wiimote_layout->addWidget(m_wiimote_passthrough, m_wiimote_layout->rowCount(), 0, 1, -1);
@@ -236,6 +238,7 @@ void WiimoteControllersWidget::CreateLayout()
     auto* wm_label = m_wiimote_labels[i] = new QLabel(tr("Wii Remote %1").arg(i + 1));
     auto* wm_box = m_wiimote_boxes[i] = new QComboBox();
     auto* wm_device = m_wiimote_device_boxes[i] = new QComboBox();
+    auto* wm_test = m_wiimote_test_buttons[i] = new QPushButton(tr("Test"));
 #ifdef _WIN32
     wm_device->addItem(tr("Default Device"), QStringLiteral("default"));
     for (const auto& dev : WASAPIStream::GetAvailableDevices())
@@ -251,6 +254,7 @@ void WiimoteControllersWidget::CreateLayout()
     m_wiimote_layout->addWidget(wm_box, wm_row, 2);
     m_wiimote_layout->addWidget(wm_button, wm_row, 3);
     m_wiimote_layout->addWidget(wm_device, wm_row, 4);
+    m_wiimote_layout->addWidget(wm_test, wm_row, 5);
   }
 
   m_wiimote_layout->addWidget(m_wiimote_real_balance_board, m_wiimote_layout->rowCount(), 1, 1, -1);
@@ -317,6 +321,8 @@ void WiimoteControllersWidget::ConnectWidgets()
             &WiimoteControllersWidget::SaveSettings);
     connect(m_wiimote_buttons[i], &QPushButton::clicked, this,
             [this, i] { OnWiimoteConfigure(i); });
+    connect(m_wiimote_test_buttons[i], &QPushButton::clicked, this,
+            [this, i] { OnTestWiimoteAudio(i); });
   }
 }
 
@@ -399,6 +405,11 @@ void WiimoteControllersWidget::OnWiimoteConfigure(size_t index)
   window->show();
 }
 
+void WiimoteControllersWidget::OnTestWiimoteAudio(size_t index)
+{
+  AudioCommon::PlayWiimoteSpeakerTestTone(Core::System::GetInstance(), index);
+}
+
 void WiimoteControllersWidget::UpdateBluetoothAdapterWidgetsEnabled(const Core::State state)
 {
   const bool running = state != Core::State::Uninitialized;
@@ -469,6 +480,7 @@ void WiimoteControllersWidget::LoadSettings(Core::State state)
     m_wiimote_labels[i]->setEnabled(enable_emu_bt);
     m_wiimote_boxes[i]->setEnabled(enable_emu_bt && !running_netplay);
     m_wiimote_device_boxes[i]->setEnabled(enable_emu_bt && m_wiimote_separate_audio->isChecked());
+    m_wiimote_test_buttons[i]->setEnabled(enable_emu_bt && m_wiimote_separate_audio->isChecked());
 
     const bool is_emu_wiimote = m_wiimote_boxes[i]->currentIndex() == 1;
     m_wiimote_buttons[i]->setEnabled(enable_emu_bt && is_emu_wiimote &&

--- a/Source/Core/DolphinQt/Config/WiimoteControllersWidget.h
+++ b/Source/Core/DolphinQt/Config/WiimoteControllersWidget.h
@@ -42,6 +42,7 @@ private:
       const std::vector<IOS::HLE::BluetoothRealDevice::BluetoothDeviceInfo>& devices);
   void OnWiimoteRefreshPressed();
   void OnWiimoteConfigure(size_t index);
+  void OnTestWiimoteAudio(size_t index);
   void StartBluetoothAdapterRefresh();
   void UpdateBluetoothAdapterWidgetsEnabled(Core::State state);
 
@@ -72,6 +73,7 @@ private:
   QCheckBox* m_wiimote_speaker_data;
   QCheckBox* m_wiimote_separate_audio;
   std::array<QComboBox*, 4> m_wiimote_device_boxes;
+  std::array<QPushButton*, 4> m_wiimote_test_buttons;
   QCheckBox* m_wiimote_ciface;
   QPushButton* m_wiimote_refresh;
   QLabel* m_bluetooth_unavailable;


### PR DESCRIPTION
## Summary
- add helper to play a Wiimote speaker test tone
- expose the helper in `AudioCommon` headers
- add "Test" buttons for each Wiimote in the controller config
- hook up the test button to play audio via separate sound streams when enabled

## Testing
- `git status --short`

